### PR TITLE
Feature/book rental stock calendar

### DIFF
--- a/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
+++ b/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import jakarta.validation.Valid;
@@ -72,17 +73,29 @@ public class RentalManageController {
     }
 
     @GetMapping("/rental/add")
-    public String add(Model model) {
+    public String add(@RequestParam(required = false) String rentalDay, @RequestParam(required = false) String val, Model model) {
         List<Stock> stockList = this.stockService.findStockAvailableAll();
         List<Account> accounts = this.accountService.findAll();
 
         model.addAttribute("rentalStatus", RentalStatus.values());
         model.addAttribute("stockList", stockList);
         model.addAttribute("accounts", accounts);
+        model.addAttribute("rentalDay",rentalDay);
+        model.addAttribute("val",val);
+
+        RentalManageDto rentalManageDto = new RentalManageDto();
+        //String型をDate型に変換
+        Date rentalDayDate  = java.sql.Date.valueOf(rentalDay);
+        rentalManageDto.setExpectedRentalOn(rentalDayDate);
+        rentalManageDto.setStockId(val);
+
+        model.addAttribute("rentalManageDto",rentalManageDto);
+    
 
         if (!model.containsAttribute("rentalManageDto")) {
             model.addAttribute("rentalManageDto", new RentalManageDto());
         }
+
 
         return "rental/add";
     }

--- a/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
+++ b/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
@@ -88,14 +88,19 @@ public class RentalManageController {
         if (!model.containsAttribute("rentalManageDto")) {
             model.addAttribute("rentalManageDto", new RentalManageDto());
         }
-        
-        String stockId = this.rentalManageService.getStockId(rentalDay,title);
-  
+
         RentalManageDto rentalManageDto = new RentalManageDto();
 
-        rentalManageDto.setExpectedRentalOn(rentalDay);
-        rentalManageDto.setStockId(stockId);
+        if(rentalDay != null){
+            rentalManageDto.setExpectedRentalOn(rentalDay);
+        }
 
+
+        if(title != null){
+            String stockId = this.rentalManageService.getStockId(rentalDay,title);
+            rentalManageDto.setStockId(stockId);
+        }
+  
         model.addAttribute("rentalManageDto",rentalManageDto);
 
         return "rental/add";

--- a/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
+++ b/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
@@ -1,10 +1,13 @@
 package jp.co.metateam.library.controller;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -73,16 +76,9 @@ public class RentalManageController {
     }
 
     @GetMapping("/rental/add")
-    public String add(@RequestParam(required = false) String rentalDay, @RequestParam(required = false) String val, Model model) {
+    public String add(@RequestParam(required = false)@DateTimeFormat(pattern = "yyyy-MM-dd") Date rentalDay, @RequestParam(required = false) String title, Model model) {
         List<Stock> stockList = this.stockService.findStockAvailableAll();
         List<Account> accounts = this.accountService.findAll();
-
-        /*
-         * １、タイトルからbook_id
-         * ２、１のidとbookmstのbookidに紐づく、かつ削除フラグnull在庫管理番号すべて
-         * ３、貸出ステータスが0,1かつ"rentalDay"かぶっているの全レコード取得
-         * ４，貸出可能な在庫情報=総利用可能在庫情報-３で取得してきた値
-         */
 
         model.addAttribute("rentalStatus", RentalStatus.values());
         model.addAttribute("stockList", stockList);
@@ -92,15 +88,15 @@ public class RentalManageController {
         if (!model.containsAttribute("rentalManageDto")) {
             model.addAttribute("rentalManageDto", new RentalManageDto());
         }
-
+        
+        String stockId = this.rentalManageService.getStockId(rentalDay,title);
+  
         RentalManageDto rentalManageDto = new RentalManageDto();
-        //String型をDate型に変換
-        Date rentalDayDate  = java.sql.Date.valueOf(rentalDay);
 
-        rentalManageDto.setExpectedRentalOn(rentalDayDate);
+        rentalManageDto.setExpectedRentalOn(rentalDay);
+        rentalManageDto.setStockId(stockId);
 
         model.addAttribute("rentalManageDto",rentalManageDto);
-    
 
         return "rental/add";
     }

--- a/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
+++ b/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
@@ -84,25 +84,18 @@ public class RentalManageController {
         model.addAttribute("stockList", stockList);
         model.addAttribute("accounts", accounts);
 
+        if (rentalDay != null && title != null) {
+            RentalManageDto rentalManageDto = new RentalManageDto();
+            String stockId = this.rentalManageService.getStockId(rentalDay, title);
+            rentalManageDto.setExpectedRentalOn(rentalDay);
+            rentalManageDto.setStockId(stockId);
+
+            model.addAttribute("rentalManageDto",rentalManageDto);
+        }
 
         if (!model.containsAttribute("rentalManageDto")) {
             model.addAttribute("rentalManageDto", new RentalManageDto());
         }
-
-        RentalManageDto rentalManageDto = new RentalManageDto();
-
-        if(rentalDay != null){
-            rentalManageDto.setExpectedRentalOn(rentalDay);
-        }
-
-
-        if(title != null){
-            String stockId = this.rentalManageService.getStockId(rentalDay,title);
-            rentalManageDto.setStockId(stockId);
-        }
-  
-        model.addAttribute("rentalManageDto",rentalManageDto);
-
         return "rental/add";
     }
 

--- a/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
+++ b/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
@@ -77,25 +77,30 @@ public class RentalManageController {
         List<Stock> stockList = this.stockService.findStockAvailableAll();
         List<Account> accounts = this.accountService.findAll();
 
+        /*
+         * １、タイトルからbook_id
+         * ２、１のidとbookmstのbookidに紐づく、かつ削除フラグnull在庫管理番号すべて
+         * ３、貸出ステータスが0,1かつ"rentalDay"かぶっているの全レコード取得
+         * ４，貸出可能な在庫情報=総利用可能在庫情報-３で取得してきた値
+         */
+
         model.addAttribute("rentalStatus", RentalStatus.values());
         model.addAttribute("stockList", stockList);
         model.addAttribute("accounts", accounts);
-        model.addAttribute("rentalDay",rentalDay);
-        model.addAttribute("val",val);
 
-        RentalManageDto rentalManageDto = new RentalManageDto();
-        //String型をDate型に変換
-        Date rentalDayDate  = java.sql.Date.valueOf(rentalDay);
-        rentalManageDto.setExpectedRentalOn(rentalDayDate);
-        rentalManageDto.setStockId(val);
-
-        model.addAttribute("rentalManageDto",rentalManageDto);
-    
 
         if (!model.containsAttribute("rentalManageDto")) {
             model.addAttribute("rentalManageDto", new RentalManageDto());
         }
 
+        RentalManageDto rentalManageDto = new RentalManageDto();
+        //String型をDate型に変換
+        Date rentalDayDate  = java.sql.Date.valueOf(rentalDay);
+
+        rentalManageDto.setExpectedRentalOn(rentalDayDate);
+
+        model.addAttribute("rentalManageDto",rentalManageDto);
+    
 
         return "rental/add";
     }

--- a/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
+++ b/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
@@ -247,6 +247,8 @@ public class RentalManageController {
 
 
         if(statusList == null){
+            FieldError fieldError = new FieldError("rentalManageDto", "stockId", "現在この書籍は貸出できません");
+            result.addError(fieldError);
             throw new Exception("errorMessage");
         }
 

--- a/src/main/java/jp/co/metateam/library/controller/StockController.java
+++ b/src/main/java/jp/co/metateam/library/controller/StockController.java
@@ -143,7 +143,8 @@ public class StockController {
         Integer daysInMonth = startDate.lengthOfMonth();
 
         List<Object> daysOfWeek = this.stockService.generateDaysOfWeek(targetYear, targetMonth, startDate, daysInMonth);
-        List<String> stocks = this.stockService.generateValues(targetYear, targetMonth, daysInMonth);
+        List<List<String>> stocks = this.stockService.generateValues(targetYear, targetMonth, daysInMonth);
+        
 
         model.addAttribute("targetYear", targetYear);
         model.addAttribute("targetMonth", targetMonth);
@@ -151,6 +152,7 @@ public class StockController {
         model.addAttribute("daysInMonth", daysInMonth);
 
         model.addAttribute("stocks", stocks);
+
 
         return "stock/calendar";
     }

--- a/src/main/java/jp/co/metateam/library/model/RentalManageDto.java
+++ b/src/main/java/jp/co/metateam/library/model/RentalManageDto.java
@@ -1,6 +1,8 @@
 package jp.co.metateam.library.model;
 
 import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Date;
 import java.util.Optional;
 
@@ -71,4 +73,29 @@ public class RentalManageDto {
         }
         return Optional.empty();
     }
+    public String DateError(RentalManage rentalManage, RentalManageDto rentalManageDto) {
+ 
+        LocalDate nowDate = LocalDate.now(ZoneId.of("Asia/Tokyo"));
+     
+        Integer prestatus = rentalManage.getStatus();
+        Integer poststatus = rentalManageDto.getStatus();
+     
+        LocalDate expectedRentalOn = rentalManageDto.getExpectedRentalOn().toInstant().atZone(ZoneId.systemDefault())
+            .toLocalDate();
+     
+        LocalDate expectedReturnOn = rentalManageDto.getExpectedReturnOn().toInstant().atZone(ZoneId.systemDefault())
+            .toLocalDate();
+     
+        if (prestatus == 0 && poststatus == 1) {
+          if (!expectedRentalOn.equals(nowDate)) {
+            return "現在の日付を選択してください";
+          }
+        }
+        if (prestatus == 1 && poststatus == 2) {
+          if (!expectedReturnOn.equals(nowDate)) {
+            return "現在日付に選択してください";
+          }
+        }
+        return null;
+      }
 }

--- a/src/main/java/jp/co/metateam/library/repository/BookMstRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/BookMstRepository.java
@@ -15,10 +15,11 @@ public interface BookMstRepository extends JpaRepository<BookMst, Long> {
 
 	Optional<BookMst> findById(BigInteger id);
 
-	 //書籍情報を取得
-    // @Query("SELECT bm FROM BookMst bm WHERE bm.deletedAt IS NULL;")
-	// List<BookMst> findAllBookData();
-
+	//書籍情報を取得
 	@Query("SELECT bm FROM BookMst bm WHERE bm.deletedAt IS NULL")
-List<BookMst> findAllBookData();
+	List<BookMst> findAllBookData();
+
+	//書籍タイトルから書籍情報を取得
+	@Query("SELECT bm FROM BookMst bm WHERE bm.title = ?1 AND bm.deletedAt IS NULL")
+	List<BookMst> findByBookTitle(String title);
 }

--- a/src/main/java/jp/co/metateam/library/repository/BookMstRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/BookMstRepository.java
@@ -1,8 +1,10 @@
 package jp.co.metateam.library.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import jp.co.metateam.library.model.BookMst;
+import jp.co.metateam.library.service.StockService;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -12,4 +14,11 @@ public interface BookMstRepository extends JpaRepository<BookMst, Long> {
 	List<BookMst> findAll();
 
 	Optional<BookMst> findById(BigInteger id);
+
+	 //書籍情報を取得
+    // @Query("SELECT bm FROM BookMst bm WHERE bm.deletedAt IS NULL;")
+	// List<BookMst> findAllBookData();
+
+	@Query("SELECT bm FROM BookMst bm WHERE bm.deletedAt IS NULL")
+List<BookMst> findAllBookData();
 }

--- a/src/main/java/jp/co/metateam/library/repository/RentalManageRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/RentalManageRepository.java
@@ -28,4 +28,6 @@ public interface RentalManageRepository extends JpaRepository<RentalManage, Long
     @Query("SELECT COUNT(rm) FROM RentalManage rm WHERE rm.stock.id = ?1 AND rm.status IN (0,1) AND ( rm.expectedRentalOn > ?2 OR rm.expectedReturnOn < ?3)")
     Long addOtherDates(String stock_id, Date expectedReturnOn, Date expectedRentalOn);
 
+    @Query("select r from RentalManage r where r.stockId = ?1 and r.status in (0, 1)")
+    List<RentalManage> findByStockIdAndStatus(String newStockId);
 }

--- a/src/main/java/jp/co/metateam/library/repository/RentalManageRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/RentalManageRepository.java
@@ -9,6 +9,9 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import jp.co.metateam.library.model.RentalManage;
+import jp.co.metateam.library.model.Stock;
+
+import jp.co.metateam.library.service.StockService;
 
 @Repository
 public interface RentalManageRepository extends JpaRepository<RentalManage, Long> {
@@ -16,18 +19,26 @@ public interface RentalManageRepository extends JpaRepository<RentalManage, Long
 
    Optional<RentalManage> findById(Long id);
 
-    @Query("SELECT COUNT(rm) FROM RentalManage rm WHERE rm.stock.id = ?1 AND rm.status IN (0,1) AND rm.id <> ?2")
+    @Query("SELECT COUNT (rm) FROM RentalManage rm WHERE rm.stock.id = ?1 AND rm.status IN (0,1) AND rm.id <> ?2")
     Long otherReservations(String stock_id,Long id);
 
-    @Query("SELECT COUNT(rm) FROM RentalManage rm WHERE rm.stock.id = ?1 AND rm.status IN (0,1) AND rm.id <> ?2 AND ( rm.expectedRentalOn > ?3 OR rm.expectedReturnOn < ?4)")
+    @Query("SELECT COUNT (rm) FROM RentalManage rm WHERE rm.stock.id = ?1 AND rm.status IN (0,1) AND rm.id <> ?2 AND ( rm.expectedRentalOn > ?3 OR rm.expectedReturnOn < ?4)")
     Long otherDates(String stock_id,Long id,Date expectedReturnOn,Date expectedRentalOn);
 
-    @Query("SELECT COUNT(rm) FROM RentalManage rm WHERE rm.stock.id = ?1 AND rm.status IN (0,1)")
+    @Query("SELECT COUNT (rm) FROM RentalManage rm WHERE rm.stock.id = ?1 AND rm.status IN (0,1)")
     Long addOtherReservations(String stock_id);
 
-    @Query("SELECT COUNT(rm) FROM RentalManage rm WHERE rm.stock.id = ?1 AND rm.status IN (0,1) AND ( rm.expectedRentalOn > ?2 OR rm.expectedReturnOn < ?3)")
+    @Query("SELECT COUNT (rm) FROM RentalManage rm WHERE rm.stock.id = ?1 AND rm.status IN (0,1) AND ( rm.expectedRentalOn > ?2 OR rm.expectedReturnOn < ?3)")
     Long addOtherDates(String stock_id, Date expectedReturnOn, Date expectedRentalOn);
 
-    @Query("select r from RentalManage r where r.stockId = ?1 and r.status in (0, 1)")
-    List<RentalManage> findByStockIdAndStatus(String newStockId);
+
+    //ここから在庫カレンダー
+    //ステータスが「貸出待ち」の他の貸出期間と被っている情報
+    @Query("SELECT COUNT (rm) FROM RentalManage rm WHERE rm.status = 0 AND (rm.expectedRentalOn <= ?1 AND rm.expectedReturnOn >= ?1) AND rm.stock.id IN ?2")
+    Long scheduledRentaWaitData(Date day, List<String>stock_id);
+
+    //ステータスが「貸出中」の他の貸出期間と被っている情報
+    @Query("SELECT COUNT (rm) FROM RentalManage rm WHERE rm.status = 1 AND (rm.rentaledAt <= ?1 AND rm.expectedReturnOn >= ?1) AND rm.stock.id IN ?2")
+    Long scheduledRentalingData(Date day, List<String>stock_id);
+
 }

--- a/src/main/java/jp/co/metateam/library/repository/RentalManageRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/RentalManageRepository.java
@@ -38,7 +38,7 @@ public interface RentalManageRepository extends JpaRepository<RentalManage, Long
     Long scheduledRentaWaitData(Date day, List<String>stock_id);
 
     //ステータスが「貸出中」の他の貸出期間と被っている情報
-    @Query("SELECT COUNT (rm) FROM RentalManage rm WHERE rm.status = 1 AND (rm.rentaledAt <= ?1 AND rm.expectedReturnOn >= ?1) AND rm.stock.id IN ?2")
-    Long scheduledRentalingData(Date day, List<String>stock_id);
+    @Query(value ="SELECT * FROM rental_manage as rm WHERE CAST(rm.rentaled_At as date) <= :date AND :date <= rm.expected_return_on AND rm.stock_id IN(:stockId) AND rm.status= 1",nativeQuery = true)
+    List<RentalManage> scheduledRentalingData(Date date, List<String> stockId);
 
 }

--- a/src/main/java/jp/co/metateam/library/repository/StockRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/StockRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import jp.co.metateam.library.model.Stock;
@@ -20,4 +21,11 @@ public interface StockRepository extends JpaRepository<Stock, Long> {
 	Optional<Stock> findById(String id);
     
     List<Stock> findByBookMstIdAndStatus(Long book_id,Integer status);
+
+// //利用可能な総在庫数を取得
+//     @Query("SELECT s FROM Stock s WHERE s.book.id = ?1 AND stock.status = 0 ")
+//     List<Stock> findAllStockDate(Long book_id);
+
+@Query("SELECT s FROM Stock s WHERE s.status = 0 AND s.bookMst.id = ?1 AND s.deletedAt IS NULL")
+List<Stock> findAllAvailableStockData(Long bookId);
 }

--- a/src/main/java/jp/co/metateam/library/repository/StockRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/StockRepository.java
@@ -22,10 +22,15 @@ public interface StockRepository extends JpaRepository<Stock, Long> {
     
     List<Stock> findByBookMstIdAndStatus(Long book_id,Integer status);
 
-// //利用可能な総在庫数を取得
-//     @Query("SELECT s FROM Stock s WHERE s.book.id = ?1 AND stock.status = 0 ")
-//     List<Stock> findAllStockDate(Long book_id);
-
+// 利用可能な総在庫数を取得
 @Query("SELECT s FROM Stock s WHERE s.status = 0 AND s.bookMst.id = ?1 AND s.deletedAt IS NULL")
 List<Stock> findAllAvailableStockData(Long bookId);
+
+ 
+// @Query("SELECT DISTINCT s FROM Stock s LEFT OUTER JOIN RentalManage rm ON s.id = rm.stock.id WHERE ?1 BETWEEN rm.expectedRentalOn AND rm.expectedReturnOn AND s.bookMst.id = ?2 AND s.status = 0 AND deletedAt IS null")
+//   List<Stock> lendableBook(Date choiceDate, Long id);
+
+// @Query("SELECT s FROM Stock s WHERE s.status = 0 AND s.bookMst.id = ?1 " + "AND deletedAt IS null")
+//   List<Stock> bookStockAvailable(Long id);
+
 }

--- a/src/main/java/jp/co/metateam/library/repository/StockRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/StockRepository.java
@@ -1,5 +1,6 @@
 package jp.co.metateam.library.repository;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -22,15 +23,15 @@ public interface StockRepository extends JpaRepository<Stock, Long> {
     
     List<Stock> findByBookMstIdAndStatus(Long book_id,Integer status);
 
-// 利用可能な総在庫数を取得
-@Query("SELECT s FROM Stock s WHERE s.status = 0 AND s.bookMst.id = ?1 AND s.deletedAt IS NULL")
-List<Stock> findAllAvailableStockData(Long bookId);
+    // 利用可能な総在庫数を取得
+    @Query("SELECT s FROM Stock s WHERE s.status = 0 AND s.bookMst.id = ?1 AND s.deletedAt IS NULL")
+    List<Stock> findAllAvailableStockData(Long bookId);
 
  
-// @Query("SELECT DISTINCT s FROM Stock s LEFT OUTER JOIN RentalManage rm ON s.id = rm.stock.id WHERE ?1 BETWEEN rm.expectedRentalOn AND rm.expectedReturnOn AND s.bookMst.id = ?2 AND s.status = 0 AND deletedAt IS null")
-//   List<Stock> lendableBook(Date choiceDate, Long id);
+    @Query("SELECT DISTINCT s.id FROM Stock s LEFT OUTER JOIN RentalManage rm ON s.id = rm.stock.id WHERE ?1 BETWEEN rm.expectedRentalOn AND rm.expectedReturnOn AND s.bookMst.id = ?2 AND s.status = 0 AND deletedAt IS null")
+     List<String> findLendableBook(Date choiceDate, Long id);
 
-// @Query("SELECT s FROM Stock s WHERE s.status = 0 AND s.bookMst.id = ?1 " + "AND deletedAt IS null")
-//   List<Stock> bookStockAvailable(Long id);
+    @Query("SELECT s.id FROM Stock s WHERE s.status = 0 AND s.bookMst.id = ?1 AND deletedAt IS null")
+     List<String> findBookStockAvailable(Long id);
 
 }

--- a/src/main/java/jp/co/metateam/library/service/RentalManageService.java
+++ b/src/main/java/jp/co/metateam/library/service/RentalManageService.java
@@ -3,7 +3,6 @@ package jp.co.metateam.library.service;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Date;
-import java.time.LocalDate;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/jp/co/metateam/library/service/RentalManageService.java
+++ b/src/main/java/jp/co/metateam/library/service/RentalManageService.java
@@ -8,7 +8,14 @@ import java.time.LocalDate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
+import jakarta.validation.Valid;
 import jp.co.metateam.library.model.Account;
 import jp.co.metateam.library.model.RentalManage;
 import jp.co.metateam.library.model.RentalManageDto;
@@ -25,20 +32,19 @@ public class RentalManageService {
     private final RentalManageRepository rentalManageRepository;
     private final StockRepository stockRepository;
 
-     @Autowired
+    @Autowired
     public RentalManageService(
-        AccountRepository accountRepository,
-        RentalManageRepository rentalManageRepository,
-        StockRepository stockRepository
-    ) {
+            AccountRepository accountRepository,
+            RentalManageRepository rentalManageRepository,
+            StockRepository stockRepository) {
         this.accountRepository = accountRepository;
         this.rentalManageRepository = rentalManageRepository;
         this.stockRepository = stockRepository;
     }
 
     @Transactional
-    public List <RentalManage> findAll() {
-        List <RentalManage> rentalManageList = this.rentalManageRepository.findAll();
+    public List<RentalManage> findAll() {
+        List<RentalManage> rentalManageList = this.rentalManageRepository.findAll();
 
         return rentalManageList;
     }
@@ -48,16 +54,19 @@ public class RentalManageService {
         return this.rentalManageRepository.findById(id).orElse(null);
     }
 
-
     @Transactional
-    public Long  otherReservations(String stock_id,Long id){
-        return this.rentalManageRepository.otherReservations(stock_id,id);
+    public List<RentalManage> findByStockIdAndStatus(String newStockId) {
+        return this.findByStockIdAndStatus(newStockId);
     }
 
-    
     @Transactional
-    public Long otherDates(String stock_id,Long id,Date expectedReturnOn,Date expectedRentalOn){
-        return this.rentalManageRepository.otherDates(stock_id,id,expectedReturnOn,expectedRentalOn);
+    public Long otherReservations(String stock_id, Long id) {
+        return this.rentalManageRepository.otherReservations(stock_id, id);
+    }
+
+    @Transactional
+    public Long otherDates(String stock_id, Long id, Date expectedReturnOn, Date expectedRentalOn) {
+        return this.rentalManageRepository.otherDates(stock_id, id, expectedReturnOn, expectedRentalOn);
     }
 
     @Transactional
@@ -67,10 +76,10 @@ public class RentalManageService {
 
     @Transactional
     public long addOtherDates(String stock_id, Date expectedReturnOn, Date expectedRentalOn) {
-        return this.rentalManageRepository.addOtherDates(stock_id, expectedReturnOn,expectedRentalOn);
+        return this.rentalManageRepository.addOtherDates(stock_id, expectedReturnOn, expectedRentalOn);
     }
-    
-    @Transactional 
+
+    @Transactional
     public void save(RentalManageDto rentalManageDto) throws Exception {
         try {
             Account account = this.accountRepository.findByEmployeeId(rentalManageDto.getEmployeeId()).orElse(null);
@@ -101,7 +110,7 @@ public class RentalManageService {
 
     private RentalManage setRentalStatusDate(RentalManage rentalManage, Integer status) {
         Timestamp timestamp = new Timestamp(System.currentTimeMillis());
-        
+
         if (status == RentalStatus.RENTAlING.getValue()) {
             rentalManage.setRentaledAt(timestamp);
         } else if (status == RentalStatus.RETURNED.getValue()) {
@@ -112,8 +121,9 @@ public class RentalManageService {
 
         return rentalManage;
     }
-    @Transactional 
-    public void update(Long id,RentalManageDto rentalManageDto) throws Exception {
+
+    @Transactional
+    public void update(Long id, RentalManageDto rentalManageDto) throws Exception {
         try {
             // 既存レコード取得
             Account account = this.accountRepository.findByEmployeeId(rentalManageDto.getEmployeeId()).orElse(null);
@@ -128,7 +138,6 @@ public class RentalManageService {
             updateTRental.setExpectedReturnOn(rentalManageDto.getExpectedReturnOn());
             updateTRental.setStock(stock);
             updateTRental.setStatus(rentalManageDto.getStatus());
-            
 
             // データベースへの保存
             this.rentalManageRepository.save(updateTRental);
@@ -136,4 +145,36 @@ public class RentalManageService {
             throw e;
         }
     }
+
+    public String check(Long id,RentalManageDto rentalManageDto) {
+
+        String newStockId = rentalManageDto.getStockId();
+        // 在庫管理番号に紐づいたステータスのうち「0」か「1」の情報を持ってくる
+        List<RentalManage> statusList = this.findByStockIdAndStatus(newStockId);
+        // 取得したデータが0件だった場合
+        if (statusList == null) {
+
+            return "この本は新規で貸出登録してください";
+        }
+        // ステータスが「0」か「1」の場合を比べる
+        Date newExRentaledAt = rentalManageDto.getExpectedRentalOn();
+        Date newExReturnedAt = rentalManageDto.getExpectedReturnOn();
+
+        for (RentalManage List : statusList) {
+            Date exRentaledAt = List.getExpectedRentalOn();
+            Date exReturnedAt = List.getExpectedReturnOn();
+
+            if (id != List.getId()) {
+                if (!(newExReturnedAt.before(exRentaledAt)) && !(exReturnedAt.before(newExRentaledAt))) {
+                    String errorMessage = "現在この書籍は利用中のため貸出できません";
+
+                    return errorMessage;
+
+                }
+
+            }
+        }
+        return null;
+    }
+
 }

--- a/src/main/java/jp/co/metateam/library/service/StockService.java
+++ b/src/main/java/jp/co/metateam/library/service/StockService.java
@@ -65,16 +65,6 @@ public class StockService {
         return this.stockRepository.findAllAvailableStockData(bookId);
     }
 
-    // @Transactional
-    // public List<Stock> lendableBook(Date choiceDate, Long id) {
-    //     return this.stockRepository.lendableBook(choiceDate, id);
-    // }
-
-    // @Transactional
-    // public List<Stock> bookStockAvailable(Long id) {
-    //     return this.stockRepository.bookStockAvailable(id);
-    // }
-
     @Transactional
     public Long scheduledRentaWaitData(Date day, List<String>stock_id) {
         return this.rentalManageRepository.scheduledRentaWaitData(day, stock_id);

--- a/src/main/java/jp/co/metateam/library/service/StockService.java
+++ b/src/main/java/jp/co/metateam/library/service/StockService.java
@@ -136,6 +136,7 @@ public class StockService {
         List<List<String>> bigValues = new ArrayList<>();
         //BookMstテーブルのすべての書籍情報をリストに追加
         List<BookMst> bookData = findAllBookData();
+        LocalDate today = LocalDate.now();
     
         //書籍数分ループ
         for (BookMst book : bookData){
@@ -173,6 +174,10 @@ public class StockService {
                 //計算してtotalに入れたデータを String型のtotalValueに変換
                 String totalValue = Long.toString(total);
 
+                if (today.isAfter(localDate)) {
+                    totalValue = "0";
+                }
+                
                 //取得した日付ごとの利用可能在庫数をbookInfoに入れる
                 bookInfo.add(totalValue);
 

--- a/src/main/java/jp/co/metateam/library/service/StockService.java
+++ b/src/main/java/jp/co/metateam/library/service/StockService.java
@@ -1,11 +1,12 @@
 package jp.co.metateam.library.service;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
-import java.util.Random;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -16,17 +17,20 @@ import jp.co.metateam.library.model.BookMst;
 import jp.co.metateam.library.model.Stock;
 import jp.co.metateam.library.model.StockDto;
 import jp.co.metateam.library.repository.BookMstRepository;
+import jp.co.metateam.library.repository.RentalManageRepository;
 import jp.co.metateam.library.repository.StockRepository;
 
 @Service
 public class StockService {
     private final BookMstRepository bookMstRepository;
     private final StockRepository stockRepository;
+    private final RentalManageRepository rentalManageRepository;
 
     @Autowired
-    public StockService(BookMstRepository bookMstRepository, StockRepository stockRepository){
+    public StockService(BookMstRepository bookMstRepository, StockRepository stockRepository,RentalManageRepository rentalManageRepository){
         this.bookMstRepository = bookMstRepository;
         this.stockRepository = stockRepository;
+        this.rentalManageRepository = rentalManageRepository;
     }
 
     @Transactional
@@ -46,6 +50,28 @@ public class StockService {
     @Transactional
     public Stock findById(String id) {
         return this.stockRepository.findById(id).orElse(null);
+    }
+
+    @Transactional
+    public List<BookMst> findAllBookData() {
+        List<BookMst> findAllBookData = this.bookMstRepository.findAllBookData();
+
+        return  findAllBookData;
+    }
+
+    @Transactional
+    public List<Stock> findAllAvailableStockData(Long bookId) {
+        return this.stockRepository.findAllAvailableStockData(bookId);
+    }
+
+    @Transactional
+    public Long scheduledRentaWaitData(Date day, List<String>stock_id) {
+        return this.rentalManageRepository.scheduledRentaWaitData(day, stock_id);
+    }
+
+    @Transactional
+    public Long scheduledRentalingData(Date day, List<String>stock_id) {
+        return this.rentalManageRepository.scheduledRentalingData(day,stock_id);
     }
 
     @Transactional 
@@ -105,19 +131,58 @@ public class StockService {
         return daysOfWeek;
     }
 
-    public List<String> generateValues(Integer year, Integer month, Integer daysInMonth) {
-        // FIXME ここで各書籍毎の日々の在庫を生成する処理を実装する
-        // FIXME ランダムに値を返却するサンプルを実装している
-        String[] stockNum = {"1", "2", "3", "4", "×"};
-        Random rnd = new Random();
-        List<String> values = new ArrayList<>();
-        values.add("スッキリわかるJava入門 第4版"); // 対象の書籍名
-        values.add("10"); // 対象書籍の在庫総数
-        
-        for (int i = 1; i <= daysInMonth; i++) {
-            int index = rnd.nextInt(stockNum.length);
-            values.add(stockNum[index]);
+    public List<List<String>> generateValues(Integer year, Integer month, Integer daysInMonth) {
+        //2次元のStringをつめるbigValuesっていう箱を作る
+        List<List<String>> bigValues = new ArrayList<>();
+        //BookMstテーブルのすべての書籍情報をリストに追加
+        List<BookMst> bookData = findAllBookData();
+    
+        //書籍数分ループ
+        for (BookMst bookLoop : bookData){
+            //bigValuesっていう大きな箱の中の各書籍の情報を入れるvaluesって箱
+            List<String> values = new ArrayList<>();
+            //valuesって箱にループしてきたタイトルをつめてる
+            values.add(bookLoop.getTitle());
+
+            //利用可能総在庫数
+            List<Stock> availableStocks = findAllAvailableStockData(bookLoop.getId());
+            //数字を文字列に変換　　　　　　　　　　　　　　↓.sizeでavailableStocksの中身を数えてる
+            String availableStocksCount = String.valueOf(availableStocks.size());
+            //数えたやつをvaluesに追加
+            values.add(availableStocksCount);
+
+            List<String> stockId = new ArrayList<>();
+            for(Stock stock : availableStocks) {
+                stockId.add(stock.getId());
+            }
+
+
+            //日付ごとの利用可能在庫数を入れるリストを作る
+
+            //日付分ループ
+             for(int dayOfMonth = 1; dayOfMonth <= daysInMonth; dayOfMonth++){
+                //対象の日付を取得
+                LocalDate localDate = LocalDate.of(year,month,dayOfMonth);
+                //LocalDate型のlocalDateををDate型に変換しdateに入れる
+                Date date = Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
+                //日ごとの利用可能在庫数
+                Long scheduledRentaWaitDataCount = scheduledRentaWaitData(date,stockId);
+                Long scheduledRentalingDataCount = scheduledRentalingData(date,stockId);
+
+                Long total =  (availableStocks.size()) - ( scheduledRentaWaitDataCount + scheduledRentalingDataCount);
+
+                String totalValue = Long.toString(total);
+
+                ///日付ごとの利用可能在庫数をリストに入れる
+
+
+             }
+
+            bigValues.add(values);
+
         }
-        return values;
+        return bigValues;
     }
 }
+
+ 

--- a/src/main/java/jp/co/metateam/library/service/StockService.java
+++ b/src/main/java/jp/co/metateam/library/service/StockService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import jp.co.metateam.library.constants.Constants;
 import jp.co.metateam.library.model.BookMst;
+import jp.co.metateam.library.model.RentalManage;
 import jp.co.metateam.library.model.Stock;
 import jp.co.metateam.library.model.StockDto;
 import jp.co.metateam.library.repository.BookMstRepository;
@@ -64,14 +65,27 @@ public class StockService {
         return this.stockRepository.findAllAvailableStockData(bookId);
     }
 
+    // @Transactional
+    // public List<Stock> lendableBook(Date choiceDate, Long id) {
+    //     return this.stockRepository.lendableBook(choiceDate, id);
+    // }
+
+    // @Transactional
+    // public List<Stock> bookStockAvailable(Long id) {
+    //     return this.stockRepository.bookStockAvailable(id);
+    // }
+
     @Transactional
     public Long scheduledRentaWaitData(Date day, List<String>stock_id) {
         return this.rentalManageRepository.scheduledRentaWaitData(day, stock_id);
     }
 
     @Transactional
-    public Long scheduledRentalingData(Date day, List<String>stock_id) {
-        return this.rentalManageRepository.scheduledRentalingData(day,stock_id);
+    public long scheduledRentalingData(Date date, List<String> stockId) {
+      List<RentalManage> unavailableStockLists = this.rentalManageRepository.scheduledRentalingData(date, stockId);
+      long unavailableStockNum =unavailableStockLists.size();
+ 
+      return unavailableStockNum;
     }
 
     @Transactional 
@@ -158,7 +172,7 @@ public class StockService {
              //stockIdって箱にループしてきたIdをつめてる
                 stockIdList.add(stock.getId());
             }
-
+            
 
             //日付分ループ
              for(int dayOfMonth = 1; dayOfMonth <= daysInMonth; dayOfMonth++){
@@ -180,7 +194,7 @@ public class StockService {
                 
                 //取得した日付ごとの利用可能在庫数をbookInfoに入れる
                 bookInfo.add(totalValue);
-
+                //bookInfo.addAll(stockIdList);
              }
 
             bigValues.add(bookInfo);

--- a/src/main/java/jp/co/metateam/library/service/StockService.java
+++ b/src/main/java/jp/co/metateam/library/service/StockService.java
@@ -138,26 +138,26 @@ public class StockService {
         List<BookMst> bookData = findAllBookData();
     
         //書籍数分ループ
-        for (BookMst bookLoop : bookData){
-            //bigValuesっていう大きな箱の中の各書籍の情報を入れるvaluesって箱
-            List<String> values = new ArrayList<>();
-            //valuesって箱にループしてきたタイトルをつめてる
-            values.add(bookLoop.getTitle());
+        for (BookMst book : bookData){
+            //bigValuesっていう大きな箱の中の各書籍の情報を入れるbookInfoって箱
+            List<String> bookInfo = new ArrayList<>();
+            //bookInfoって箱にループしてきたタイトルをつめてる
+            bookInfo.add(book.getTitle());
 
             //利用可能総在庫数
-            List<Stock> availableStocks = findAllAvailableStockData(bookLoop.getId());
+            List<Stock> availableStocks = findAllAvailableStockData(book.getId());
             //数字を文字列に変換　　　　　　　　　　　　　　↓.sizeでavailableStocksの中身を数えてる
             String availableStocksCount = String.valueOf(availableStocks.size());
-            //数えたやつをvaluesに追加
-            values.add(availableStocksCount);
+            //数えたやつをbookInfoに追加
+            bookInfo.add(availableStocksCount);
 
-            List<String> stockId = new ArrayList<>();
+
+            List<String> stockIdList = new ArrayList<>();
             for(Stock stock : availableStocks) {
-                stockId.add(stock.getId());
+             //stockIdって箱にループしてきたIdをつめてる
+                stockIdList.add(stock.getId());
             }
 
-
-            //日付ごとの利用可能在庫数を入れるリストを作る
 
             //日付分ループ
              for(int dayOfMonth = 1; dayOfMonth <= daysInMonth; dayOfMonth++){
@@ -166,19 +166,19 @@ public class StockService {
                 //LocalDate型のlocalDateををDate型に変換しdateに入れる
                 Date date = Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
                 //日ごとの利用可能在庫数
-                Long scheduledRentaWaitDataCount = scheduledRentaWaitData(date,stockId);
-                Long scheduledRentalingDataCount = scheduledRentalingData(date,stockId);
+                Long scheduledRentaWaitDataCount = scheduledRentaWaitData(date,stockIdList);
+                Long scheduledRentalingDataCount = scheduledRentalingData(date,stockIdList);
 
-                Long total =  (availableStocks.size()) - ( scheduledRentaWaitDataCount + scheduledRentalingDataCount);
-
+                Long total =  availableStocks.size() - (scheduledRentaWaitDataCount + scheduledRentalingDataCount);
+                //計算してtotalに入れたデータを String型のtotalValueに変換
                 String totalValue = Long.toString(total);
 
-                ///日付ごとの利用可能在庫数をリストに入れる
-
+                //取得した日付ごとの利用可能在庫数をbookInfoに入れる
+                bookInfo.add(totalValue);
 
              }
 
-            bigValues.add(values);
+            bigValues.add(bookInfo);
 
         }
         return bigValues;

--- a/src/main/resources/templates/stock/calendar.html
+++ b/src/main/resources/templates/stock/calendar.html
@@ -43,7 +43,7 @@
                                         <!--1個以上だったらリンクかつ、数字を表示、0個だったら×を表示 -->
                                         <!-- 個数チェックの分岐 -->
                                         <!-- 在庫数が1個以上の場合のみ表示する -->
-                                        <a th:if="${val} gt 0" th:text="${val}" th:href="@{/rental/add(rentalDay=${#dates.format(#dates.create(targetYear, targetMonth,i.index - 1 ) , ('yyyy-MM-dd'))},val=${stocks.get(stat.index).get(0)})}"></a>
+                                        <a th:if="${val} gt 0" th:text="${val}" th:href="@{/rental/add(rentalDay=${#dates.format(#dates.create(targetYear, targetMonth,i.index - 1 ) , ('yyyy-MM-dd'))},title=${stocks.get(stat.index).get(0)})}"></a>
                                         <p th:unless="${val} gt 0" th:text="'×'"></p>
                                     </div>
                                 </td>

--- a/src/main/resources/templates/stock/calendar.html
+++ b/src/main/resources/templates/stock/calendar.html
@@ -36,12 +36,19 @@
                             </tr>
                         </thead>
                         <tbody>
-                            <tr th:each="stock : ${stocks}">
-                                <td th:each="val : ${stock}">
-                                    <p th:text="${val} gt '0' ? ${val} : '×'"></p>
+                            <tr th:each="stock : ${stocks}"> <!--ストックスの要素をストックが一個ずつ取り出してる -->
+                                <td th:each="val, i : ${stock}"> <!--valとindexがわかる -->
+                                    <p th:if="${i.index lt 2}" th:text="${val}"></p>
+                                    <div th:unless="${i.index lt 2}">
+                                        <!--1個以上だったらリンクかつ、数字を表示、0個だったら×を表示 -->
+                                        <!-- 個数チェックの分岐 -->
+                                         <!-- 在庫数が1個以上の場合のみ表示する -->
+                                        <a th:if="${val} gt 0" th:text="${val}" th:href="@{/rental/add(val=${val})}"></a>
+                                        <p th:unless="${val} gt 0" th:text="'×'"></p>
+                                    </div>
                                 </td>
-                            </tr>
                             <!-- FIXME ControllerやService側の処理とともに表示方法を考える -->
+                            </tr>
                         </tbody>
                     </table>
                 </div>

--- a/src/main/resources/templates/stock/calendar.html
+++ b/src/main/resources/templates/stock/calendar.html
@@ -36,14 +36,14 @@
                             </tr>
                         </thead>
                         <tbody>
-                            <tr th:each="stock : ${stocks}"> <!--ストックスの要素をストックが一個ずつ取り出してる -->
-                                <td th:each="val, i : ${stock}"> <!--valとindexがわかる -->
-                                    <p th:if="${i.index lt 2}" th:text="${val}"></p>
+                            <tr th:each="stock, stat : ${stocks}"> <!--ストックスの要素をストックが一個ずつ取り出してる -->
+                                <td th:each="val, i : ${stock}"> <!--valとindexがわかる --><!--iが回数 -->
+                                    <p th:if="${i.index lt 2}" th:text="${val}"></p><!--1回目タイトル、２回目総在庫数はそのまま表示 --><!--２回目より小さかったらそのまま表示 -->
                                     <div th:unless="${i.index lt 2}">
                                         <!--1個以上だったらリンクかつ、数字を表示、0個だったら×を表示 -->
                                         <!-- 個数チェックの分岐 -->
                                         <!-- 在庫数が1個以上の場合のみ表示する -->
-                                        <a th:if="${val} gt 0" th:text="${val}" th:href="@{/rental/add(val=${val})}"></a>
+                                        <a th:if="${val} gt 0" th:text="${val}" th:href="@{/rental/add(rentalDay=${#dates.format(#dates.create(targetYear, targetMonth,i.index - 1 ) , ('yyyy-MM-dd'))},val=${stocks.get(stat.index).get(0)})}"></a>
                                         <p th:unless="${val} gt 0" th:text="'×'"></p>
                                     </div>
                                 </td>

--- a/src/main/resources/templates/stock/calendar.html
+++ b/src/main/resources/templates/stock/calendar.html
@@ -37,11 +37,11 @@
                         </thead>
                         <tbody>
                             <tr th:each="stock : ${stocks}">
-                                 <td th:text="${stock[0]}"></td>
-                                 <td th:text="${stock[1]}"></td>
-                                 <td th:text="${stock[2]}"></td>
-                             </tr>
-                             <!-- FIXME ControllerやService側の処理とともに表示方法を考える -->
+                                <td th:each="val : ${stock}">
+                                    <p th:text="${val} gt '0' ? ${val} : '×'"></p>
+                                </td>
+                            </tr>
+                            <!-- FIXME ControllerやService側の処理とともに表示方法を考える -->
                         </tbody>
                     </table>
                 </div>

--- a/src/main/resources/templates/stock/calendar.html
+++ b/src/main/resources/templates/stock/calendar.html
@@ -42,7 +42,7 @@
                                     <div th:unless="${i.index lt 2}">
                                         <!--1個以上だったらリンクかつ、数字を表示、0個だったら×を表示 -->
                                         <!-- 個数チェックの分岐 -->
-                                         <!-- 在庫数が1個以上の場合のみ表示する -->
+                                        <!-- 在庫数が1個以上の場合のみ表示する -->
                                         <a th:if="${val} gt 0" th:text="${val}" th:href="@{/rental/add(val=${val})}"></a>
                                         <p th:unless="${val} gt 0" th:text="'×'"></p>
                                     </div>

--- a/src/main/resources/templates/stock/calendar.html
+++ b/src/main/resources/templates/stock/calendar.html
@@ -13,11 +13,20 @@
             <div class="inner_contens">
                 <div class="page_title">在庫カレンダー</div>
                 <div class="month_change mb30">
-                    <div><a th:href="@{/stock/calendar(year=2024,month=*{targetMonth-1})}">前月</a></div>
-                    <div th:text="${targetYear + '年' + targetMonth + '月'}"></div>
-                    <div><a th:href="@{/stock/calendar(year=2024,month=*{targetMonth+1})}">翌月</a></div>
+                    <!--<div><a th:href="@{/stock/calendar(year=2024,month=*{targetMonth-1})}">前月</a></div>-->
+                     <!--<div th:text="${targetYear + '年' + targetMonth + '月'}"></div>-->
+                     <!--<div><a th:href="@{/stock/calendar(year=2024,month=*{targetMonth+1})}">翌月</a></div>-->
+                <!--</div>-->
+                <div>
+                    <a th:if="${targetMonth == 1}" th:href="@{/stock/calendar(year=${targetYear-1},month=12)}">前月</a>
+                    <a th:if="${targetMonth != 1}" th:href="@{/stock/calendar(year=*{targetYear},month=${targetMonth-1})}">前月</a>
                 </div>
-
+                    <div th:text="${targetYear + '年' + targetMonth + '月'}"></div>
+                <div>
+                    <a th:if="${targetMonth == 12}" th:href="@{/stock/calendar(year=${targetYear+1},month=1)}">翌月</a>
+                    <a th:if="${targetMonth != 12}" th:href="@{/stock/calendar(year=${targetYear},month=${targetMonth+1})}">翌月</a>
+                </div>
+                </div>
                 <div class="table_wrapper">
                     <table id="calendar_table">
                         <colgroup>

--- a/src/main/resources/templates/stock/calendar.html
+++ b/src/main/resources/templates/stock/calendar.html
@@ -36,10 +36,12 @@
                             </tr>
                         </thead>
                         <tbody>
-                            <tr>
-                                <!-- FIXME ControllerやService側の処理とともに表示方法を考える -->
-                                <td th:each="stock, stat : ${stocks}" th:text="${stock}"></td>
-                            </tr>
+                            <tr th:each="stock : ${stocks}">
+                                 <td th:text="${stock[0]}"></td>
+                                 <td th:text="${stock[1]}"></td>
+                                 <td th:text="${stock[2]}"></td>
+                             </tr>
+                             <!-- FIXME ControllerやService側の処理とともに表示方法を考える -->
                         </tbody>
                     </table>
                 </div>


### PR DESCRIPTION
【 概要】
在庫カレンダー機能を追加
→日付ごとの在庫数を押下し、貸出登録画面に遷移。貸出予定日と在庫管理番号の初期表示にセット
→過去日の場合×を表示
→在庫数０の場合×を表示

【証跡】
・貸出したい書籍とその日付に対応した利用可能在庫数を押下
・貸出登録画面に遷移するリンクになっていて貸出予定日と在庫管理番号を受け渡す
・貸出登録画面に遷移すると選択した貸出予定日と在庫管理番号がセットされている
・在庫カレンダーから貸出登録を行った際に正しく登録ができ、在庫カレンダーで在庫数が減ったことを確認